### PR TITLE
Support Totara sites irrespective of allowlogincsrf setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ When presenting a login page that contains a form - many users will ignore all l
 
 This plugin provides a custom splash page that only shows the IDP/SSO buttons and (optionally) a link to the manual Moodle login form.
 
-Once installed, set the alternateloginurl setting in moodle to yourmoodleurl/local/login/index.php 
+Once installed, set the alternateloginurl setting in moodle to yourmoodleurl/local/login/index.php
 
 
 ## Installing via uploaded ZIP file ##
@@ -40,10 +40,6 @@ Afterwards, run
     $ php server/admin/cli/upgrade.php
 
 to complete the installation from the command line.
-
-Totara 15+ requires applying the following setting in config.php
-
-    $CFG->allowlogincsrf = 1;
 
 ## License ##
 

--- a/lang/en/local_login.php
+++ b/lang/en/local_login.php
@@ -45,6 +45,7 @@ $string['backgroundimage'] = 'Background image';
 $string['backgroundimage_desc'] = 'Background image that appears on the local login page.';
 $string['forcelogin'] = 'Force login when accessing site homepage';
 $string['forcelogin_desc'] = 'If the user is accessing the site homepage and the user is not currently logged in, this will redirect them to the login page';
+$string['forceloginredirect'] = 'Force login page redirect.';
+$string['forceloginredirect_desc'] = 'This setting allow Totara sites to use this without needing to change the csrftoken setting. Currently applicable on Totara 15+ sites. Refer to TL-19365 for details. ';
 $string['showmnet'] = 'Show mnet providers';
 $string['showmnet_desc'] = 'If mnet is enabled, these options will be included on the local login page.';
-

--- a/lib.php
+++ b/lib.php
@@ -76,19 +76,22 @@ function local_login_backgroundimage() {
  *
  */
 function local_login_after_config() {
-
     global $CFG, $FULLME;
-    $forcelogin = get_config('local_login', 'forcelogin');
     $noredirect  = optional_param('noredirect', 0, PARAM_BOOL); // Don't redirect.
-    if (stripos($FULLME, $CFG->wwwroot.'/login/index.php') === 0 &&
-       !isloggedin() && !empty($noredirect) && !empty($CFG->alternateloginurl)) {
-        unset($CFG->alternateloginurl);
+    $forceloginredirect = get_config('local_login', 'forceloginredirect');
+    if (stripos($FULLME, $CFG->wwwroot.'/login/index.php') === 0 && !isloggedin()) {
+        if (!empty($noredirect) && !empty($CFG->alternateloginurl)) {
+             unset($CFG->alternateloginurl);
+        } else if ($forceloginredirect && !data_submitted()) {
+            redirect($CFG->wwwroot.'/local/login/index.php');
+        }
     }
+    // If forcelogin is enabled then only logged in users can access site homepage.
+    $forcelogin = get_config('local_login', 'forcelogin');
     $wwwrootpath = parse_url($CFG->wwwroot, PHP_URL_PATH);
     $fullmepath = parse_url($FULLME, PHP_URL_PATH);
     $path = str_replace($wwwrootpath, "", $fullmepath);
     if ((empty($path) || $path == '/' || $path == '/index.php') && !isloggedin() && $forcelogin == 1) {
         redirect($CFG->wwwroot.'/login/index.php');
     }
-
 }

--- a/settings.php
+++ b/settings.php
@@ -47,6 +47,12 @@ if ($hassiteconfig) { // Needs this condition or there is error on login page.
          0)
     );
 
+    $settings->add(new admin_setting_configcheckbox('local_login/forceloginredirect',
+        get_string('forceloginredirect', 'local_login'),
+        get_string('forceloginredirect_desc', 'local_login'),
+         0)
+    );
+
     $settings->add(new admin_setting_configcheckbox('local_login/showmnet',
         get_string('showmnet', 'local_login'),
         get_string('showmnet_desc', 'local_login'),


### PR DESCRIPTION
This resolves support Totara without needing the csrftoken setting change https://github.com/catalyst/moodle-local_login/issues/14.