### PR TITLE
Improve null handling for php 8.1 compatibility

### DIFF
--- a/lib.php
+++ b/lib.php
@@ -79,7 +79,7 @@ function local_login_after_config() {
     global $CFG, $FULLME;
     $noredirect  = optional_param('noredirect', 0, PARAM_BOOL); // Don't redirect.
     $forceloginredirect = get_config('local_login', 'forceloginredirect');
-    if (!$FULLME || stripos($FULLME, $CFG->wwwroot.'/login/index.php') === 0 && !isloggedin()) {
+    if (!empty($FULLME) && stripos($FULLME, $CFG->wwwroot.'/login/index.php') === 0 && !isloggedin()) {
         if (!empty($noredirect) && !empty($CFG->alternateloginurl)) {
              unset($CFG->alternateloginurl);
         } else if (empty($noredirect) && $forceloginredirect && !data_submitted()) {
@@ -89,10 +89,7 @@ function local_login_after_config() {
     // If forcelogin is enabled then only logged in users can access site homepage.
     $forcelogin = get_config('local_login', 'forcelogin');
     $wwwrootpath = parse_url($CFG->wwwroot, PHP_URL_PATH);
-    $fullmepath = "";
-    if (isset($FULLME)) {
-        $fullmepath = parse_url($FULLME, PHP_URL_PATH);
-    }
+    $fullmepath = !empty($FULLME) ? parse_url($FULLME, PHP_URL_PATH) : '';
     $path = str_replace($wwwrootpath, "", $fullmepath);
     if ((empty($noredirect) && empty($path) || $path == '/' || $path == '/index.php') && !isloggedin() && $forcelogin == 1  ) {
         redirect($CFG->wwwroot.'/login/index.php');

--- a/lib.php
+++ b/lib.php
@@ -79,7 +79,7 @@ function local_login_after_config() {
     global $CFG, $FULLME;
     $noredirect  = optional_param('noredirect', 0, PARAM_BOOL); // Don't redirect.
     $forceloginredirect = get_config('local_login', 'forceloginredirect');
-    if (stripos($FULLME, $CFG->wwwroot.'/login/index.php') === 0 && !isloggedin()) {
+    if (!$FULLME || stripos($FULLME, $CFG->wwwroot.'/login/index.php') === 0 && !isloggedin()) {
         if (!empty($noredirect) && !empty($CFG->alternateloginurl)) {
              unset($CFG->alternateloginurl);
         } else if (empty($noredirect) && $forceloginredirect && !data_submitted()) {
@@ -89,7 +89,10 @@ function local_login_after_config() {
     // If forcelogin is enabled then only logged in users can access site homepage.
     $forcelogin = get_config('local_login', 'forcelogin');
     $wwwrootpath = parse_url($CFG->wwwroot, PHP_URL_PATH);
-    $fullmepath = parse_url($FULLME, PHP_URL_PATH);
+    $fullmepath = "";
+    if (isset($FULLME)) {
+        $fullmepath = parse_url($FULLME, PHP_URL_PATH);
+    }
     $path = str_replace($wwwrootpath, "", $fullmepath);
     if ((empty($noredirect) && empty($path) || $path == '/' || $path == '/index.php') && !isloggedin() && $forcelogin == 1  ) {
         redirect($CFG->wwwroot.'/login/index.php');


### PR DESCRIPTION
parse_url(): Passing null to parameter #1 ($url) of type string is deprecated
stripos(): Passing null to parameter #1 ($haystack) of type string is deprecated