### PR TITLE
Prevent auto-redirect after log in attempt with no learner account

### DIFF
--- a/classes/output/login.php
+++ b/classes/output/login.php
@@ -32,9 +32,10 @@ class login {
      * Output login buttons to page.
      *
      * @param string $wantsurl
+     * @param boolean $accounterror
      * @return string
      */
-    public static function output_login_options($wantsurl) {
+    public static function output_login_options($wantsurl, $accounterror) {
         // Could have used a renderer, but just nicer to have everything in the same file.
         $config = get_config('local_login');
         // Output.
@@ -69,7 +70,7 @@ class login {
         }
         // If only one IDP is available in authentication plugins then auto-redirect to it.
         $noredirect  = optional_param('noredirect', 0, PARAM_BOOL); // Don't redirect.
-        if ($count === 1 && get_config('local_login', 'autoredirect')  && empty($noredirect)) {
+        if ($count === 1 && get_config('local_login', 'autoredirect') && empty($noredirect) && !$accounterror) {
             redirect($idploginpath);
         }
 

--- a/index.php
+++ b/index.php
@@ -36,6 +36,13 @@ if (isloggedin() && !isguestuser()) {
 }
 
 $wantsurl = empty($SESSION->wantsurl) ? '' : $SESSION->wantsurl;
+$loginerrormsg = empty($SESSION->loginerrormsg) ? '' : $SESSION->loginerrormsg;
+$accounterror = false;
+
+if ($loginerrormsg === 'The login attempt failed. Reason: An account with your email address could not be created.') {
+    $accounterror = true;
+}
+
 
 $context = context_system::instance();
 $PAGE->set_url("{$CFG->wwwroot}/local/login/index.php");
@@ -52,13 +59,19 @@ $PAGE->navbar->ignore_active();
 $loginsite = get_string("loginsite");
 $PAGE->navbar->add($loginsite);
 
-$loginoptions = \local_login\output\login::output_login_options($wantsurl);
+$loginoptions = \local_login\output\login::output_login_options($wantsurl, $accounterror);
 
 echo $OUTPUT->header();
 
 $config = get_config('local_login');
 if (!empty($config->headertext)) {
     echo format_text($config->headertext);
+}
+
+if ($accounterror) {
+    echo '<div class="loginerrors">';
+    echo $OUTPUT->error_text($loginerrormsg);
+    echo '</div>';
 }
 
 echo $loginoptions;


### PR DESCRIPTION
If the auto-redirect option is enabled but the person trying to log in doesn't have an account in Moodle, they get caught into an infinite loop of redirects between Moodle and the Idp.

This fix catches the 'The login attempt failed. Reason: An account with your email address could not be created.' error to escape the auto-redirect.