### PR TITLE
Allow login error messages to be displayed correctly

### DIFF
--- a/classes/output/renderer.php
+++ b/classes/output/renderer.php
@@ -107,7 +107,8 @@ class renderer extends \plugin_renderer_base {
                 $manual->beforemanual = format_text($config->beforemanualtext);
             }
 
-            $name = !empty($config->custommanualtext) ? format_string($config->custommanualtext) : get_string('manuallogin', 'local_login');
+            $name = !empty($config->custommanualtext) ?
+                format_string($config->custommanualtext) : get_string('manuallogin', 'local_login');
             $manual->manualname = $name;
 
             $mustachecontext->manual = $manual;

--- a/index.php
+++ b/index.php
@@ -24,6 +24,7 @@
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
+// phpcs:ignore moodle.Files.RequireLogin.Missing
 require_once('../../config.php');
 require_once($CFG->dirroot.'/login/lib.php');
 require_once($CFG->libdir.'/authlib.php');

--- a/lang/en/local_login.php
+++ b/lang/en/local_login.php
@@ -44,7 +44,7 @@ $string['customlogindisabled'] = 'Site settings prevent this page from being use
 $string['backgroundimage'] = 'Background image';
 $string['backgroundimage_desc'] = 'Background image that appears on the local login page.';
 $string['forcelogin'] = 'Force login when accessing site homepage';
-$string['forcelogin_desc'] = 'If the user is accessing the site homepage and the user is not currently logged in, this will redirect them to the login page. 
+$string['forcelogin_desc'] = 'If the user is accessing the site homepage and the user is not currently logged in, this will redirect them to the login page.
 Please note that if you are using a Totara 15+ site, you need to tick forceloginredirect setting below. ';
 $string['forceloginredirect'] = 'Force login page redirect.';
 $string['forceloginredirect_desc'] = 'This setting allow Totara sites to use this without needing to change the csrftoken setting. Currently applicable on Totara 15+ sites. Refer to TL-19365 for details. ';

--- a/lib.php
+++ b/lib.php
@@ -89,9 +89,9 @@ function local_login_after_config() {
     // If forcelogin is enabled then only logged in users can access site homepage.
     $forcelogin = get_config('local_login', 'forcelogin');
     $wwwrootpath = parse_url($CFG->wwwroot, PHP_URL_PATH);
-    $fullmepath = !empty($FULLME) ? parse_url($FULLME, PHP_URL_PATH) : '';
+    $path = !empty($FULLME) ? parse_url($FULLME, PHP_URL_PATH) : '';
     if (!empty($wwwrootpath)) {
-        $path = str_replace($wwwrootpath, "", $fullmepath);
+        $path = str_replace($wwwrootpath, "", $path);
     }
     if ((empty($noredirect) && empty($path) || $path == '/' || $path == '/index.php') && !isloggedin() && $forcelogin == 1  ) {
         redirect($CFG->wwwroot.'/login/index.php');

--- a/lib.php
+++ b/lib.php
@@ -76,13 +76,14 @@ function local_login_backgroundimage() {
  *
  */
 function local_login_after_config() {
-    global $CFG, $FULLME;
+    global $CFG, $FULLME, $SESSION;
     $noredirect  = optional_param('noredirect', 0, PARAM_BOOL); // Don't redirect.
     $forceloginredirect = get_config('local_login', 'forceloginredirect');
     if (!empty($FULLME) && stripos($FULLME, $CFG->wwwroot.'/login/index.php') === 0 && !isloggedin()) {
+        $noredirect = $noredirect || data_submitted() || !empty($SESSION->loginerrormsg);
         if (!empty($noredirect) && !empty($CFG->alternateloginurl)) {
              unset($CFG->alternateloginurl);
-        } else if (empty($noredirect) && $forceloginredirect && !data_submitted()) {
+        } else if (empty($noredirect) && $forceloginredirect) {
             redirect($CFG->wwwroot.'/local/login/index.php');
         }
     }


### PR DESCRIPTION
Currently when manual auth has an error (i.e. incorrect password) it is forced to redirect to the alternateloginurl before it even sets the error message in the session.

Solution to the problem is to unset alternateloginurl when on the manual login page and data has been submitted or an error message is set in the session.

I've also fixed up a warning for $path being undefined when $CFG->wwwroot doesn't have a path.

Testing:
- Have `/local/login/index.php` set in alternateloginurl
- Be logged out
- Try to access the site, you should be redirected to /local/login/index.php
- On the /local/login/index.php page click on the manual login button
- Enter incorrect credentials
- You should see the error message and not be redirected back to /local/login/index.php